### PR TITLE
Fix keggGet() error in 2.2 section of submodule 3

### DIFF
--- a/AWS/Submodule03-ProcessingPathwayInformation.ipynb
+++ b/AWS/Submodule03-ProcessingPathwayInformation.ipynb
@@ -62,7 +62,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7afff25e-ab25-42d7-abbf-1d8f58927ae2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "IRdisplay::display_html('<iframe src=\"../Quizzes/Quiz_Submodule3-1.html\" width=100% height=250></iframe>')"
@@ -167,7 +171,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "de58632b-8af1-494f-bd43-bc88d3d31010",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "#Run the following command to take the quiz\n",
@@ -220,7 +228,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1724cdf4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Importing the packages\n",
@@ -243,7 +255,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8554f2b2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Download the limma_results.rds file to the \"data\" folder in current directory\n",
@@ -258,7 +274,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ecbba43f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Get a numeric vector with names as gene ID from DE results for retrieving GO terms\n",
@@ -280,7 +300,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9f65ad1d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Retrieve all the GO terms related to the gene list obtained from the expression matrix\n",
@@ -301,7 +325,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6c12b8cf",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Obtain a list of genes for each GO term\n",
@@ -322,7 +350,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "44a524db-1cb7-4dc5-8ce3-e15c2ce4922b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Import GO.db package\n",
@@ -341,7 +373,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d43fe956",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Getting the name of each GO term\n",
@@ -354,7 +390,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4201d92e-f88c-4807-ad6c-5713b3776cac",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "descriptions[1:10]"
@@ -372,7 +412,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "87443760",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "#' Function to save Gene Ontology (GO) terms with gene sets to local storage in GMT format.\n",
@@ -410,7 +454,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3241cbe2-03b5-4ccd-9e16-ecd05ebc6d1e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# save the GO terms with genesets to Amazon S3 Bucket\n",
@@ -438,7 +486,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e3753d02-54e2-4f58-9484-5f697bbfc040",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "#Run the following command to take the quiz\n",
@@ -460,7 +512,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9c2dbd0f-6933-4dcd-b552-7d5a9b9b22a5",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Import KEGGREST package\n",
@@ -481,7 +537,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7628359f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# List all available databases in KEGGREST\n",
@@ -502,7 +562,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2a577ddb",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Get the list of organisms available in KEGG\n",
@@ -513,7 +577,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "459b1e4d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "print(paste0(\"KEGG supports \", dim(organism)[1], \" organisms\"))"
@@ -531,7 +599,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e89ee1aa",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# View several supported organism\n",
@@ -542,7 +614,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c780749a-55ee-490d-afed-09bf11508670",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "IRdisplay::display_html('<iframe src=\"../Quizzes/Quiz_Submodule3-3.html\" width=100% height=250></iframe>')"
@@ -560,7 +636,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "029e2990",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Obtain the pathways belong to human\n",
@@ -579,7 +659,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "85de2fd0-fb3b-4e3e-bf46-a1cc27e61704",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "#list the specific pathways to view\n",
@@ -600,7 +684,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b81aecd9-42b5-4771-b9a5-a4d667fccd2a",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "#Run the following command to take the quiz\n",
@@ -619,7 +707,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "80faa8d2-7b63-49ae-8273-0590bb4d6166",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Retrieve all the pathway IDs belong to human\n",
@@ -639,7 +731,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a04ba7ce-6c41-4a90-8c3f-0225ed370651",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "print(paste0(\"Number of available pathways for human are: \", length(pathway.codes)))"
@@ -659,33 +755,28 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ffb8f1e4-a0cc-4495-b003-c7d94a5b4787",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "# Create indexes for the outer loop\n",
-    "idx4loop <- seq(from = 1, to = length(pathway.codes), by = 9)\n",
-    "idx4loop <- c(idx4loop, length(pathway.codes))\n",
-    "# Create list to store the gene sets\n",
     "genes.by.pathway <- list()\n",
     "description.by.pathway <- list()\n",
     "\n",
-    "# Loop through the each index in idx4loop\n",
-    "for (i in 1:length(idx4loop)) {\n",
-    "    if (i < length(idx4loop)) {\n",
-    "        # Get the ten pathways names to query using keggGet\n",
-    "        pathways_names <- pathway.codes[idx4loop[i]: idx4loop[i+1]]\n",
-    "        pw <- keggGet(pathways_names)\n",
-    "        for (j in 1:length(pw)) {\n",
-    "            pw2 <- pw[[j]]\n",
-    "            # If the returned result of a pathway does not have the key \"GENE\", skip to the next pathway id\n",
-    "            if (is.null(pw2$GENE)) next\n",
-    "            description.by.pathway[[pathways_names[[j]]]] <-  pw2$NAME          \n",
-    "\n",
-    "            pw2 <- pw2$GENE[c(FALSE, TRUE)]\n",
-    "            pw2 <- unlist(lapply(strsplit(pw2, split = \";\", fixed = T), function(x) x[1]))\n",
-    "            genes.by.pathway[[pathways_names[[j]]]] <- pw2\n",
-    "        } \n",
-    "    } \n",
+    "for (p in pathway.codes) {\n",
+    "  pw <- tryCatch(keggGet(p), error = function(e) NULL)\n",
+    "  if (is.null(pw)) next\n",
+    "  \n",
+    "  pw2 <- pw[[1]]\n",
+    "  if (is.null(pw2$GENE)) next\n",
+    "  \n",
+    "  description.by.pathway[[p]] <- pw2$NAME\n",
+    "  \n",
+    "  pw2 <- pw2$GENE[c(FALSE, TRUE)]\n",
+    "  pw2 <- unlist(lapply(strsplit(pw2, \";\", fixed = TRUE), function(x) x[1]))\n",
+    "  genes.by.pathway[[p]] <- pw2\n",
     "}\n",
     "                                 "
    ]
@@ -702,7 +793,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ac62baff",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# View the five pathways with the genesets\n",
@@ -721,7 +816,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1f600459-2347-4d12-b988-6e0017198e82",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# View the description of the first five pathways\n",
@@ -740,7 +839,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "94a98586-782d-4576-9a6c-6cd281c3c520",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Saving the pathway data to the local repository\n",
@@ -752,7 +855,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dafa08b2-de3b-4689-ad97-40973d13c315",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Saving the pathway information to the Amazon S3 Bucket\n",
@@ -794,7 +901,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "daeea4df-538e-4105-b41f-f530c162a080",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Import the ReactomeContentService4R package\n",
@@ -821,7 +932,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b18c3da0-9803-47d2-99a0-5651dc6f3f61",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Retrieve the pathways information using the getSchemaClass function\n",
@@ -841,7 +956,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bf977557-6ef7-4228-97ff-f747c64df85d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Get the pathway ID and the pathway description from the pathways information\n",
@@ -862,7 +981,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "020b4ec7-365e-4e6e-9087-e0d745f4854f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create the geneset list \n",
@@ -881,7 +1004,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "20383b1c-0715-4376-95aa-bc1571af445e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Print out some first pathways and their genes IDs\n",
@@ -892,7 +1019,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fa55486d-f540-425a-b044-16718831267b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Print out some first pathways and their descriptions\n",
@@ -911,7 +1042,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cd9dd8c5-2e0c-4f7a-984c-5d310e3df949",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Saving the pathway information to the local repository\n",
@@ -923,7 +1058,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c480eba3-2ec8-4299-ad1f-c1abdbdecf18",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Saving the pathway information to the Amazon S3 Bucket\n",
@@ -972,7 +1111,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "72feb66c-fd96-4c6b-b8fd-98a52c9bba13",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "sessionInfo()"


### PR DESCRIPTION
There is a known bug in KEGGREST::keggGet() when you query too many pathways at once. The KEGG API sometimes returns entries (like overview maps hsa01100, hsa01200, etc.) that don’t have the expected REFERENCE field or have slightly different formatting. That breaks the parser inside KEGGREST. When keggGet() fetches a batch that includes an overview pathway (like hsa01100 "Global Metabolic Pathways"), it returns a record without the REFERENCE field → the parser fails. Instead of doing batch, query the pathway one at a time.

genes.by.pathway <- list()
description.by.pathway <- list()

for (p in pathway.codes) {
  pw <- tryCatch(keggGet(p), error = function(e) NULL)
  if (is.null(pw)) next
  
  pw2 <- pw[[1]]
  if (is.null(pw2$GENE)) next
  
  description.by.pathway[[p]] <- pw2$NAME
  
  pw2 <- pw2$GENE[c(FALSE, TRUE)]
  pw2 <- unlist(lapply(strsplit(pw2, ";", fixed = TRUE), function(x) x[1]))
  genes.by.pathway[[p]] <- pw2
}

This avoids batching and skips broken pathways gracefully.
